### PR TITLE
feat: parallel stem hashing with rayon (#7)

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -12,6 +12,12 @@ use alloy_primitives::B256;
 /// Per EIP-7864, the hash function has special rules:
 /// - `hash([0x00] * 64) = [0x00] * 32` (empty input produces zero hash)
 /// - For all other inputs, use the underlying hash function
+///
+/// # Thread Safety
+///
+/// This trait is always `Send + Sync` so that hashers can be used safely in
+/// parallel contexts (e.g. stem hashing via the `"parallel"` feature with rayon).
+/// Custom hasher implementations must be thread-safe.
 pub trait Hasher: Clone + Default + Send + Sync {
     /// Hash a 32-byte value (for leaf nodes)
     fn hash_32(&self, value: &B256) -> B256;


### PR DESCRIPTION
## Summary
Implements parallel stem hash computation using rayon when the `parallel` feature is enabled.

Closes igor53627/reth-ubt-exex#7

## Changes
- Added parallel version of `rebuild_root()` using `par_iter()` for stem hash computation
- Sequential cache updates after parallel hashing (thread-safe pattern)
- Added test to verify parallel produces same results as sequential

## Benchmarks
From previous analysis, stem hashing takes ~96% of rebuild time. With 8 cores:
- 100K stems: 146ms (serial) -> ~18ms expected (parallel)

## Testing
```bash
cargo test --features parallel
cargo bench --features parallel
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "parallel" feature flag to enable parallel hash recomputation for faster processing when enabled.
* **Documentation**
  * Clarified thread-safety requirements for the hashing implementation to indicate it must be safe for concurrent use.
* **Tests**
  * Expanded test coverage to include scenarios for both parallel and serial execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->