### PR TITLE
feat: NodeStore trait for pluggable storage backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ubt"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "alloy-primitives",
  "blake3",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This crate provides a binary tree structure intended to replace Ethereum's hexar
 - **ZK-friendly**: Designed for efficient proving in ZK circuits
 - **Parallel hashing**: Uses rayon for concurrent stem hash computation (enabled by default)
 - **Incremental updates**: O(D*C) root updates instead of O(S log S) full rebuilds
+- **Pluggable storage**: `NodeStore` trait allows custom backends (RocksDB, redb) for persistent state
 - **Formally verified**: Core operations proven correct using the Rocq proof assistant
 
 ## Requirements
@@ -128,6 +129,27 @@ tree.root_hash().unwrap(); // Only recomputes paths to changed stems
 ```
 
 See [docs/incremental-updates.md](docs/incremental-updates.md) for benchmarks and when to use each mode.
+
+### Custom Storage Backend
+
+The tree is generic over the `NodeStore` trait, which abstracts stem node storage. The default `InMemoryStore` uses a `HashMap`. To integrate with a persistent database, implement `NodeStore` for your backend:
+
+```rust
+use ubt::{NodeStore, UnifiedBinaryTree, Blake3Hasher};
+
+// Implement NodeStore for your backend
+// struct MyStore { /* RocksDB handle, etc. */ }
+// impl NodeStore for MyStore { /* ... */ }
+
+// Construct tree with custom store
+// let store = MyStore::open("path/to/db");
+// let mut tree = UnifiedBinaryTree::<Blake3Hasher, MyStore>::with_store(store);
+
+// Access the store directly for backend-specific operations (e.g., commit/flush)
+// tree.store_mut().flush();
+```
+
+The `with_store()` constructor correctly handles both empty and pre-populated stores. You can also extract the store back with `into_store()`.
 
 ### Working with Accounts
 
@@ -306,7 +328,8 @@ formal/
 ```
 ubt/
 ├── src/             # Rust implementation
-│   ├── tree.rs      # Main tree structure
+│   ├── tree/        # Main tree structure (mod, build, hash)
+│   ├── store.rs     # NodeStore trait and InMemoryStore
 │   ├── node.rs      # Node types
 │   ├── key.rs       # Tree keys and stems
 │   ├── hash.rs      # Hash trait and implementations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! - **ZK-friendly**: Designed for efficient proving in ZK circuits
 //! - **Parallel hashing**: Uses rayon for concurrent stem hash computation (default feature)
 //! - **Incremental updates**: O(D*C) root updates instead of O(S log S) rebuilds
+//! - **Pluggable storage**: [`NodeStore`] trait allows custom backends for persistent state
 //!
 //! ## Tree Structure
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ mod hash;
 mod key;
 mod node;
 mod proof;
+mod store;
 mod streaming;
 mod tree;
 
@@ -114,6 +115,7 @@ pub use embedding::{
 pub use proof::{generate_stem_proof, Direction, MultiProof, Proof, ProofNode, Witness};
 #[doc(hidden)]
 pub use std::collections::HashMap;
+pub use store::{InMemoryStore, NodeStore};
 pub use streaming::StreamingTreeBuilder;
 pub use tree::UnifiedBinaryTree;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,0 +1,131 @@
+//! Storage backend abstraction for the UBT.
+//!
+//! The [`NodeStore`] trait abstracts how stem nodes are stored, enabling
+//! custom backends (e.g., RocksDB, redb) for persistent storage.
+//! The default [`InMemoryStore`] uses a `HashMap`.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use crate::{Stem, StemNode};
+
+/// Backend storage for UBT stem nodes.
+///
+/// Implementations provide the key-value store that [`crate::UnifiedBinaryTree`]
+/// uses for its stem node data. The default [`InMemoryStore`] wraps a `HashMap`.
+///
+/// A persistent store (e.g., backed by RocksDB or redb) would implement this
+/// trait with an internal read-through cache: load stems into memory on access,
+/// and flush dirty nodes via a store-specific `commit()` method accessible
+/// through [`UnifiedBinaryTree::store_mut`](crate::UnifiedBinaryTree::store_mut).
+///
+/// # Thread Safety
+///
+/// `Send + Sync` are required because the tree may hash stems in parallel
+/// (via rayon when the `parallel` feature is enabled).
+pub trait NodeStore: Clone + Debug + Send + Sync {
+    /// Retrieve a stem node by its stem key.
+    fn get(&self, stem: &Stem) -> Option<&StemNode>;
+
+    /// Retrieve a mutable reference to a stem node.
+    fn get_mut(&mut self, stem: &Stem) -> Option<&mut StemNode>;
+
+    /// Get a mutable reference to a stem node, creating it if absent.
+    ///
+    /// If the stem does not exist, inserts a new `StemNode::new(stem)`.
+    fn get_or_create(&mut self, stem: Stem) -> &mut StemNode;
+
+    /// Remove a stem node. No-op if the stem does not exist.
+    fn remove(&mut self, stem: &Stem);
+
+    /// Number of stems in the store.
+    fn len(&self) -> usize;
+
+    /// Whether the store contains no stems.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterate over all `(stem, node)` pairs.
+    fn iter(&self) -> impl Iterator<Item = (&Stem, &StemNode)>;
+
+    /// Total number of non-empty values across all stems.
+    fn value_count(&self) -> usize;
+
+    /// Hint that the store should pre-allocate for `additional` stems.
+    ///
+    /// Default implementation is a no-op.
+    fn reserve(&mut self, _additional: usize) {}
+}
+
+/// In-memory store backed by a `HashMap`.
+///
+/// This is the default store used by [`crate::UnifiedBinaryTree`].
+#[derive(Clone, Debug)]
+pub struct InMemoryStore {
+    stems: HashMap<Stem, StemNode>,
+}
+
+impl InMemoryStore {
+    /// Create a new empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stems: HashMap::new(),
+        }
+    }
+
+    /// Create a new store with pre-allocated capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            stems: HashMap::with_capacity(capacity),
+        }
+    }
+}
+
+impl Default for InMemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NodeStore for InMemoryStore {
+    fn get(&self, stem: &Stem) -> Option<&StemNode> {
+        self.stems.get(stem)
+    }
+
+    fn get_mut(&mut self, stem: &Stem) -> Option<&mut StemNode> {
+        self.stems.get_mut(stem)
+    }
+
+    fn get_or_create(&mut self, stem: Stem) -> &mut StemNode {
+        self.stems
+            .entry(stem)
+            .or_insert_with(|| StemNode::new(stem))
+    }
+
+    fn remove(&mut self, stem: &Stem) {
+        self.stems.remove(stem);
+    }
+
+    fn len(&self) -> usize {
+        self.stems.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.stems.is_empty()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Stem, &StemNode)> {
+        self.stems.iter()
+    }
+
+    fn value_count(&self) -> usize {
+        self.stems.values().map(|s| s.values.len()).sum()
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.stems.reserve(additional);
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,7 @@
 //! Storage backend abstraction for the UBT.
 //!
 //! The [`NodeStore`] trait abstracts how stem nodes are stored, enabling
-//! custom backends (e.g., RocksDB, redb) for persistent storage.
+//! custom backends (e.g., `RocksDB`, `redb`) for persistent storage.
 //! The default [`InMemoryStore`] uses a `HashMap`.
 
 use std::collections::HashMap;
@@ -14,7 +14,7 @@ use crate::{Stem, StemNode};
 /// Implementations provide the key-value store that [`crate::UnifiedBinaryTree`]
 /// uses for its stem node data. The default [`InMemoryStore`] wraps a `HashMap`.
 ///
-/// A persistent store (e.g., backed by RocksDB or redb) would implement this
+/// A persistent store (e.g., backed by `RocksDB` or `redb`) would implement this
 /// trait with an internal read-through cache: load stems into memory on access,
 /// and flush dirty nodes via a store-specific `commit()` method accessible
 /// through [`UnifiedBinaryTree::store_mut`](crate::UnifiedBinaryTree::store_mut).

--- a/src/tree/build.rs
+++ b/src/tree/build.rs
@@ -1,10 +1,11 @@
 //! Tree structure construction helpers.
 
+use crate::store::NodeStore;
 use crate::{error::Result, Hasher, InternalNode, Node, Stem, UbtError};
 
 use super::{UnifiedBinaryTree, MAX_DEPTH};
 
-impl<H: Hasher> UnifiedBinaryTree<H> {
+impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     /// Build the tree structure from a sorted list of stems using slice partitioning.
     /// This is O(n) per level with no allocations, compared to the previous O(n) allocations per level.
     pub(super) fn build_tree_from_sorted_stems(
@@ -18,7 +19,7 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
 
         if stems.len() == 1 {
             let stem = &stems[0];
-            if let Some(stem_node) = self.stems.get(stem) {
+            if let Some(stem_node) = self.store.get(stem) {
                 return Ok(Node::Stem(stem_node.clone()));
             }
             return Ok(Node::Empty);

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -5,7 +5,8 @@ use alloy_primitives::B256;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::{error::Result, Hasher, Node, Stem, StemNode, TreeKey, UbtError};
+use crate::store::NodeStore;
+use crate::{error::Result, Hasher, Node, Stem, TreeKey, UbtError};
 
 use super::{UnifiedBinaryTree, MAX_DEPTH};
 
@@ -49,7 +50,7 @@ fn b256_matches_prefix(value: &B256, prefix: &B256, depth: usize) -> bool {
     (value.0[full_bytes] & mask) == (prefix.0[full_bytes] & mask)
 }
 
-impl<H: Hasher> UnifiedBinaryTree<H> {
+impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     /// Get the root hash of the tree.
     ///
     /// This will trigger a rebuild of the tree structure if any modifications
@@ -70,7 +71,7 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
 
     /// Compute the hash for a stem node.
     fn compute_stem_hash(&self, stem: &Stem) -> B256 {
-        if let Some(stem_node) = self.stems.get(stem) {
+        if let Some(stem_node) = self.store.get(stem) {
             stem_node.hash(&self.hasher)
         } else {
             B256::ZERO
@@ -432,10 +433,7 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
         let mut inserted_any = false;
         for (key, value) in entries {
             inserted_any = true;
-            let stem_node = self
-                .stems
-                .entry(key.stem)
-                .or_insert_with(|| StemNode::new(key.stem));
+            let stem_node = self.store.get_or_create(key.stem);
             stem_node.set_value(key.subindex, value);
             self.dirty_stem_hashes.insert(key.stem);
         }
@@ -461,10 +459,7 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
         let mut inserted_any = false;
         for (key, value) in entries {
             inserted_any = true;
-            let stem_node = self
-                .stems
-                .entry(key.stem)
-                .or_insert_with(|| StemNode::new(key.stem));
+            let stem_node = self.store.get_or_create(key.stem);
             stem_node.set_value(key.subindex, value);
             self.dirty_stem_hashes.insert(key.stem);
             count += 1;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -162,6 +162,7 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     /// If the store already contains stems, they are marked dirty so that
     /// the next [`root_hash`](Self::root_hash) call computes correctly.
     pub fn with_store(store: S) -> Self {
+        let capacity = store.len();
         let dirty_stem_hashes: HashSet<Stem> = store.iter().map(|(s, _)| *s).collect();
         let root_dirty = !dirty_stem_hashes.is_empty();
         Self {
@@ -169,10 +170,10 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
             hasher: H::default(),
             store,
             root_dirty,
-            stem_hash_cache: HashMap::new(),
+            stem_hash_cache: HashMap::with_capacity(capacity),
             dirty_stem_hashes,
             root_hash_cached: B256::ZERO,
-            node_hash_cache: HashMap::new(),
+            node_hash_cache: HashMap::with_capacity(capacity * 2),
             incremental_enabled: false,
         }
     }
@@ -182,6 +183,7 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     /// If the store already contains stems, they are marked dirty so that
     /// the next [`root_hash`](Self::root_hash) call computes correctly.
     pub fn with_hasher_and_store(hasher: H, store: S) -> Self {
+        let capacity = store.len();
         let dirty_stem_hashes: HashSet<Stem> = store.iter().map(|(s, _)| *s).collect();
         let root_dirty = !dirty_stem_hashes.is_empty();
         Self {
@@ -189,10 +191,10 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
             hasher,
             store,
             root_dirty,
-            stem_hash_cache: HashMap::new(),
+            stem_hash_cache: HashMap::with_capacity(capacity),
             dirty_stem_hashes,
             root_hash_cached: B256::ZERO,
-            node_hash_cache: HashMap::new(),
+            node_hash_cache: HashMap::with_capacity(capacity * 2),
             incremental_enabled: false,
         }
     }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -158,14 +158,19 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     }
 
     /// Create a new tree with a custom storage backend.
+    ///
+    /// If the store already contains stems, they are marked dirty so that
+    /// the next [`root_hash`](Self::root_hash) call computes correctly.
     pub fn with_store(store: S) -> Self {
+        let dirty_stem_hashes: HashSet<Stem> = store.iter().map(|(s, _)| *s).collect();
+        let root_dirty = !dirty_stem_hashes.is_empty();
         Self {
             root: Node::Empty,
             hasher: H::default(),
             store,
-            root_dirty: false,
+            root_dirty,
             stem_hash_cache: HashMap::new(),
-            dirty_stem_hashes: HashSet::new(),
+            dirty_stem_hashes,
             root_hash_cached: B256::ZERO,
             node_hash_cache: HashMap::new(),
             incremental_enabled: false,
@@ -173,14 +178,19 @@ impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     }
 
     /// Create a new tree with a custom hasher and storage backend.
+    ///
+    /// If the store already contains stems, they are marked dirty so that
+    /// the next [`root_hash`](Self::root_hash) call computes correctly.
     pub fn with_hasher_and_store(hasher: H, store: S) -> Self {
+        let dirty_stem_hashes: HashSet<Stem> = store.iter().map(|(s, _)| *s).collect();
+        let root_dirty = !dirty_stem_hashes.is_empty();
         Self {
             root: Node::Empty,
             hasher,
             store,
-            root_dirty: false,
+            root_dirty,
             stem_hash_cache: HashMap::new(),
-            dirty_stem_hashes: HashSet::new(),
+            dirty_stem_hashes,
             root_hash_cached: B256::ZERO,
             node_hash_cache: HashMap::new(),
             incremental_enabled: false,
@@ -871,6 +881,38 @@ mod tests {
         assert_ne!(h1, B256::ZERO);
 
         tree.delete(&key);
+        assert_eq!(tree.root_hash().unwrap(), B256::ZERO);
+    }
+
+    #[test]
+    fn test_with_store_populated() {
+        use crate::store::InMemoryStore;
+
+        let mut tree1: UnifiedBinaryTree<Blake3Hasher> = UnifiedBinaryTree::new();
+        let k1 = TreeKey::from_bytes(B256::repeat_byte(0x01));
+        let k2 = TreeKey::from_bytes(B256::repeat_byte(0x02));
+        tree1.insert(k1, B256::repeat_byte(0x11));
+        tree1.insert(k2, B256::repeat_byte(0x22));
+        let expected_root = tree1.root_hash().unwrap();
+
+        let store = tree1.into_store();
+        assert_eq!(store.len(), 2);
+
+        let mut tree2: UnifiedBinaryTree<Blake3Hasher, InMemoryStore> =
+            UnifiedBinaryTree::with_store(store);
+        assert_eq!(tree2.stem_count(), 2);
+        assert_eq!(tree2.get(&k1), Some(B256::repeat_byte(0x11)));
+        let root = tree2.root_hash().unwrap();
+        assert_eq!(root, expected_root, "with_store on populated store must produce correct root_hash");
+    }
+
+    #[test]
+    fn test_with_store_empty() {
+        use crate::store::InMemoryStore;
+
+        let mut tree: UnifiedBinaryTree<Blake3Hasher, InMemoryStore> =
+            UnifiedBinaryTree::with_store(InMemoryStore::new());
+        assert!(tree.is_empty());
         assert_eq!(tree.root_hash().unwrap(), B256::ZERO);
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -27,6 +27,7 @@ mod hash;
 use alloy_primitives::B256;
 use std::collections::{HashMap, HashSet};
 
+use crate::store::{InMemoryStore, NodeStore};
 use crate::{Blake3Hasher, Hasher, Node, Stem, StemNode, TreeKey, STEM_LEN};
 
 /// Maximum tree depth (248 bits = 31 bytes * 8)
@@ -42,19 +43,14 @@ type NodeCacheKey = (usize, B256);
 /// A binary tree that stores 32-byte values at 32-byte keys.
 /// Keys are split into a 31-byte stem (tree path) and 1-byte subindex (within subtree).
 ///
-/// # Implementation Notes
+/// # Storage Backend
 ///
-/// ## `HashMap` vs `BTreeMap` for stems
+/// The tree is generic over [`NodeStore`], which abstracts stem node storage.
+/// The default [`InMemoryStore`] uses a `HashMap`. Custom backends (e.g., RocksDB)
+/// can be plugged in by implementing `NodeStore` and constructing the tree with
+/// [`with_store`](Self::with_store).
 ///
-/// The tree uses `HashMap` for `stems` and `stem_hash_cache` rather than `BTreeMap`.
-/// While `BTreeMap` would maintain sorted order (avoiding O(S log S) sort on rebuild),
-/// `HashMap` provides O(1) insert vs O(log S) for `BTreeMap`.
-///
-/// For typical block processing with many inserts per rebuild cycle, `HashMap` is
-/// often faster overall. If your workload is rebuild-heavy with few inserts,
-/// consider a `BTreeMap`-based variant.
-///
-/// ## Incremental Mode
+/// # Incremental Mode
 ///
 /// When `enable_incremental_mode()` is called, the tree caches intermediate node
 /// hashes in `node_hash_cache`. This makes hash recomputation O(D * C) where D=248
@@ -65,13 +61,13 @@ type NodeCacheKey = (usize, B256);
 ///
 /// This is the recommended approach for block-by-block state updates.
 #[derive(Clone, Debug)]
-pub struct UnifiedBinaryTree<H: Hasher = Blake3Hasher> {
+pub struct UnifiedBinaryTree<H: Hasher = Blake3Hasher, S: NodeStore = InMemoryStore> {
     /// Root node of the tree (kept for potential proof generation)
     root: Node,
     /// Hasher instance
     hasher: H,
-    /// Cached stem nodes for efficient access
-    stems: HashMap<Stem, StemNode>,
+    /// Stem node storage backend
+    store: S,
     /// Whether the root hash needs to be recomputed
     root_dirty: bool,
     /// Cache of stem hashes - maps stem to its computed hash
@@ -89,84 +85,104 @@ pub struct UnifiedBinaryTree<H: Hasher = Blake3Hasher> {
     incremental_enabled: bool,
 }
 
-impl<H: Hasher> Default for UnifiedBinaryTree<H> {
+impl<H: Hasher, S: NodeStore + Default> Default for UnifiedBinaryTree<H, S> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<H: Hasher> UnifiedBinaryTree<H> {
+impl<H: Hasher, S: NodeStore> UnifiedBinaryTree<H, S> {
     /// Create a new empty tree.
-    pub fn new() -> Self {
-        Self {
-            root: Node::Empty,
-            hasher: H::default(),
-            stems: HashMap::new(),
-            root_dirty: false,
-            stem_hash_cache: HashMap::new(),
-            dirty_stem_hashes: HashSet::new(),
-            root_hash_cached: B256::ZERO,
-            node_hash_cache: HashMap::new(),
-            incremental_enabled: false,
-        }
+    pub fn new() -> Self
+    where
+        S: Default,
+    {
+        Self::with_store(S::default())
     }
 
     /// Create a new tree with a custom hasher.
-    pub fn with_hasher(hasher: H) -> Self {
-        Self {
-            root: Node::Empty,
-            hasher,
-            stems: HashMap::new(),
-            root_dirty: false,
-            stem_hash_cache: HashMap::new(),
-            dirty_stem_hashes: HashSet::new(),
-            root_hash_cached: B256::ZERO,
-            node_hash_cache: HashMap::new(),
-            incremental_enabled: false,
-        }
+    pub fn with_hasher(hasher: H) -> Self
+    where
+        S: Default,
+    {
+        Self::with_hasher_and_store(hasher, S::default())
     }
 
     /// Create a new empty tree with pre-allocated capacity for stems.
     ///
     /// Use this when you know approximately how many unique stems will be inserted,
-    /// such as during bulk migrations. This avoids `HashMap` resizing overhead.
+    /// such as during bulk migrations. This avoids resizing overhead.
     ///
     /// # Example
     /// ```
     /// use ubt::{UnifiedBinaryTree, Blake3Hasher};
     /// let tree: UnifiedBinaryTree<Blake3Hasher> = UnifiedBinaryTree::with_capacity(1_000_000);
     /// ```
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self
+    where
+        S: Default,
+    {
+        let mut store = S::default();
+        store.reserve(capacity);
         Self {
             root: Node::Empty,
             hasher: H::default(),
-            stems: HashMap::with_capacity(capacity),
+            store,
             root_dirty: false,
             stem_hash_cache: HashMap::with_capacity(capacity),
             dirty_stem_hashes: HashSet::new(),
             root_hash_cached: B256::ZERO,
-            // For node_hash_cache, we estimate roughly 2x stems worth of internal nodes,
-            // which is an upper bound for a dense binary tree with S leaves. A more
-            // precise bound would be O(S), but 2x is a simple, conservative heuristic.
             node_hash_cache: HashMap::with_capacity(capacity * 2),
             incremental_enabled: false,
         }
     }
 
     /// Create a new tree with a custom hasher and pre-allocated capacity.
-    pub fn with_hasher_and_capacity(hasher: H, capacity: usize) -> Self {
+    pub fn with_hasher_and_capacity(hasher: H, capacity: usize) -> Self
+    where
+        S: Default,
+    {
+        let mut store = S::default();
+        store.reserve(capacity);
         Self {
             root: Node::Empty,
             hasher,
-            stems: HashMap::with_capacity(capacity),
+            store,
             root_dirty: false,
             stem_hash_cache: HashMap::with_capacity(capacity),
             dirty_stem_hashes: HashSet::new(),
             root_hash_cached: B256::ZERO,
-            // For node_hash_cache, we estimate roughly 2x stems worth of internal nodes,
-            // which is an upper bound for a dense binary tree with S leaves. A more
-            // precise bound would be O(S), but 2x is a simple, conservative heuristic.
             node_hash_cache: HashMap::with_capacity(capacity * 2),
+            incremental_enabled: false,
+        }
+    }
+
+    /// Create a new tree with a custom storage backend.
+    pub fn with_store(store: S) -> Self {
+        Self {
+            root: Node::Empty,
+            hasher: H::default(),
+            store,
+            root_dirty: false,
+            stem_hash_cache: HashMap::new(),
+            dirty_stem_hashes: HashSet::new(),
+            root_hash_cached: B256::ZERO,
+            node_hash_cache: HashMap::new(),
+            incremental_enabled: false,
+        }
+    }
+
+    /// Create a new tree with a custom hasher and storage backend.
+    pub fn with_hasher_and_store(hasher: H, store: S) -> Self {
+        Self {
+            root: Node::Empty,
+            hasher,
+            store,
+            root_dirty: false,
+            stem_hash_cache: HashMap::new(),
+            dirty_stem_hashes: HashSet::new(),
+            root_hash_cached: B256::ZERO,
+            node_hash_cache: HashMap::new(),
             incremental_enabled: false,
         }
     }
@@ -175,25 +191,25 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
     ///
     /// Useful when you discover more stems will be needed after initial creation.
     pub fn reserve_stems(&mut self, additional: usize) {
-        self.stems.reserve(additional);
+        self.store.reserve(additional);
         self.stem_hash_cache.reserve(additional);
         self.node_hash_cache.reserve(additional * 2);
     }
 
     /// Returns the number of unique stems in the tree.
     pub fn stem_count(&self) -> usize {
-        self.stems.len()
+        self.store.len()
     }
 
     /// Check if the tree is empty.
     pub fn is_empty(&self) -> bool {
-        self.stems.is_empty()
+        self.store.is_empty()
     }
 
     /// Get a value by its full 32-byte key.
     #[must_use]
     pub fn get(&self, key: &TreeKey) -> Option<B256> {
-        self.stems
+        self.store
             .get(&key.stem)
             .and_then(|stem_node| stem_node.get_value(key.subindex))
     }
@@ -206,10 +222,7 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
 
     /// Insert a value at the given key.
     pub fn insert(&mut self, key: TreeKey, value: B256) {
-        let stem_node = self
-            .stems
-            .entry(key.stem)
-            .or_insert_with(|| StemNode::new(key.stem));
+        let stem_node = self.store.get_or_create(key.stem);
         stem_node.set_value(key.subindex, value);
         self.dirty_stem_hashes.insert(key.stem);
         self.root_dirty = true;
@@ -222,11 +235,11 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
 
     /// Delete a value at the given key.
     pub fn delete(&mut self, key: &TreeKey) {
-        if let Some(stem_node) = self.stems.get_mut(&key.stem) {
+        if let Some(stem_node) = self.store.get_mut(&key.stem) {
             stem_node.set_value(key.subindex, B256::ZERO);
 
             if stem_node.values.is_empty() {
-                self.stems.remove(&key.stem);
+                self.store.remove(&key.stem);
             }
         }
         self.dirty_stem_hashes.insert(key.stem);
@@ -240,14 +253,12 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
     pub fn get_or_create_stem(&mut self, stem: Stem) -> &mut StemNode {
         self.dirty_stem_hashes.insert(stem);
         self.root_dirty = true;
-        self.stems
-            .entry(stem)
-            .or_insert_with(|| StemNode::new(stem))
+        self.store.get_or_create(stem)
     }
 
     /// Iterate over all (key, value) pairs in the tree.
     pub fn iter(&self) -> impl Iterator<Item = (TreeKey, B256)> + '_ {
-        self.stems.iter().flat_map(|(stem, stem_node)| {
+        self.store.iter().flat_map(|(stem, stem_node)| {
             stem_node
                 .values
                 .iter()
@@ -257,12 +268,32 @@ impl<H: Hasher> UnifiedBinaryTree<H> {
 
     /// Get the number of non-empty values in the tree.
     pub fn len(&self) -> usize {
-        self.stems.values().map(|s| s.values.len()).sum()
+        self.store.value_count()
     }
 
     /// Verify a value exists at a key.
     pub fn contains_key(&self, key: &TreeKey) -> bool {
         self.get(key).is_some()
+    }
+
+    /// Get a reference to the underlying storage backend.
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    /// Get a mutable reference to the underlying storage backend.
+    ///
+    /// Use this to call store-specific methods (e.g., `commit()` on a
+    /// persistent backend). Modifications to the store are not automatically
+    /// tracked — call [`insert`](Self::insert) or [`delete`](Self::delete)
+    /// to keep the tree's dirty-tracking consistent.
+    pub fn store_mut(&mut self) -> &mut S {
+        &mut self.store
+    }
+
+    /// Consume the tree and return the storage backend.
+    pub fn into_store(self) -> S {
+        self.store
     }
 }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -903,7 +903,10 @@ mod tests {
         assert_eq!(tree2.stem_count(), 2);
         assert_eq!(tree2.get(&k1), Some(B256::repeat_byte(0x11)));
         let root = tree2.root_hash().unwrap();
-        assert_eq!(root, expected_root, "with_store on populated store must produce correct root_hash");
+        assert_eq!(
+            root, expected_root,
+            "with_store on populated store must produce correct root_hash"
+        );
     }
 
     #[test]

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -46,7 +46,7 @@ type NodeCacheKey = (usize, B256);
 /// # Storage Backend
 ///
 /// The tree is generic over [`NodeStore`], which abstracts stem node storage.
-/// The default [`InMemoryStore`] uses a `HashMap`. Custom backends (e.g., RocksDB)
+/// The default [`InMemoryStore`] uses a `HashMap`. Custom backends (e.g., `RocksDB`)
 /// can be plugged in by implementing `NodeStore` and constructing the tree with
 /// [`with_store`](Self::with_store).
 ///


### PR DESCRIPTION
## Summary

- Introduces `NodeStore` trait abstracting stem node storage, enabling custom backends (RocksDB, redb) for persistent state
- Provides default `InMemoryStore` wrapping the existing `HashMap` behavior — full backward compatibility
- `UnifiedBinaryTree` gains `S: NodeStore = InMemoryStore` generic parameter with new constructors `with_store()` and `with_hasher_and_store()`
- Correctly handles pre-populated stores by seeding dirty-tracking state on construction

## Changes

| File | What |
|------|------|
| `src/store.rs` | New `NodeStore` trait + `InMemoryStore` implementation |
| `src/tree/mod.rs` | Tree generic over `S: NodeStore`, store accessors (`store()`, `store_mut()`, `into_store()`) |
| `src/tree/hash.rs` | Updated impl block and replaced `self.stems` with `self.store` |
| `src/tree/build.rs` | Same |
| `src/lib.rs` | Module + re-exports, updated crate docs |
| `README.md` | Custom Storage Backend section, updated feature list and project structure |

## Test plan

- [x] All 93 unit tests pass (including 2 new: `test_with_store_populated`, `test_with_store_empty`)
- [x] All 57 property-based tests pass
- [x] All 27 simulation tests pass
- [x] All 5 doc-tests pass
- [x] Clippy clean (no new warnings)
- [x] Backward compatibility verified: `UnifiedBinaryTree<Blake3Hasher>` works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable storage support with a default in-memory backend and new constructors to initialize the tree with a supplied backend; accessors to read, mutate, and extract the underlying store.

* **Documentation**
  * README updated with guidance and examples for custom storage backends.

* **Refactor**
  * Project reorganized to separate tree and storage components.

* **Tests**
  * Added tests for backend reuse and construction from empty/populated stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->