### PR TITLE
fix(embedding): update key derivation to geth V3 spec

### DIFF
--- a/backlog/tasks/task-20 - Update-key-derivation-to-V3-spec.md
+++ b/backlog/tasks/task-20 - Update-key-derivation-to-V3-spec.md
@@ -1,0 +1,40 @@
+---
+id: TASK-20
+title: Update key derivation to V3 spec (remove LE reversal)
+status: In Progress
+assignee: []
+created_date: '2026-05-01 07:30'
+labels: []
+dependencies: []
+priority: critical
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`get_binary_tree_key_inner` implements the superseded V2 spec (Jan-Apr 2026) which reverses the first 31 bytes to LE. Go-ethereum switched to V3 on Apr 13 2026 (commit `735bfd12`) — right-shift by 1, no reversal, overflow at `buf[0]`.
+
+### Impact
+- Code chunks >= 128: **wrong stems** (different from geth)
+- Storage slots >= 64: **wrong stems** (different from geth)
+- Chunks 0-127, basic data, code hash, storage 0-63: correct by coincidence (all-zero bytes)
+- Test vectors in `test_key_derivation_geth_vectors`: stale (computed against V2)
+
+### Fix
+In `get_binary_tree_key_inner` (src/embedding.rs):
+```rust
+// V2 (current, wrong):
+buf[..31].copy_from_slice(&input_key[..31]);
+buf[..31].reverse();
+if overflow { buf[31] = 1; }
+
+// V3 (correct):
+buf[1..32].copy_from_slice(&input_key[..31]);
+if overflow { buf[0] = 1; }
+```
+
+Also update:
+- Test vectors to match V3
+- Doc comments referencing the old reversal algorithm
+- Formal verification specs if applicable
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/task-21 - Update-key-derivation-to-V3-spec.md
+++ b/backlog/tasks/task-21 - Update-key-derivation-to-V3-spec.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-20
+id: TASK-21
 title: Update key derivation to V3 spec (remove LE reversal)
 status: In Progress
 assignee: []

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -17,10 +17,10 @@
 //!
 //! ## Key Derivation
 //!
-//! Per go-ethereum reference implementation, keys are derived using SHA256:
+//! Per go-ethereum V3 algorithm (`trie/bintrie/key_encoding.go`, commit `735bfd12`):
 //! ```text
-//! buf[i] = inputKey[30-i]  for i in 0..31  // reverse to little-endian
-//! buf[31] = overflow ? 1 : 0
+//! buf[0]    = overflow ? 1 : 0
+//! buf[1:32] = inputKey[0:31]   // right-shift by 1 byte
 //! key = SHA256(zeroHash[:12] || address[:] || buf[:])  // 64-byte preimage
 //! key[31] = inputKey[31]  // subindex preserved
 //! ```

--- a/src/embedding.rs
+++ b/src/embedding.rs
@@ -57,12 +57,12 @@ pub const STEM_SUBTREE_WIDTH: u64 = 256;
 /// Zero hash prefix used in key derivation (12 zero bytes)
 const ZERO_PREFIX: [u8; 12] = [0u8; 12];
 
-/// Derive a tree key using the go-ethereum algorithm.
+/// Derive a tree key using the go-ethereum V3 algorithm.
 ///
-/// Per reference implementation (`trie/bintrie/key_encoding.go`):
+/// Per reference implementation (`trie/bintrie/key_encoding.go`, commit `735bfd12`):
 /// ```text
-/// buf[i] = offset[30-i]  for i in 0..31  (reverse first 31 bytes to LE)
-/// buf[31] = overflow ? 1 : 0
+/// buf[0] = overflow ? 1 : 0
+/// buf[1..32] = offset[0..31]  (right-shift by 1 byte)
 /// key = SHA256(zeroHash[:12] || address[:] || buf[:])   (64-byte preimage)
 /// key[31] = offset[31]                                  (preserve subindex)
 /// ```
@@ -70,20 +70,16 @@ pub fn get_binary_tree_key(address: &Address, input_key: &[u8; 32]) -> TreeKey {
     get_binary_tree_key_inner(address, input_key, false)
 }
 
-/// Inner key derivation with overflow flag, matching Geth's `getBinaryTreeKey`.
+/// Inner key derivation with overflow flag, matching geth's `getBinaryTreeKey` (V3).
 fn get_binary_tree_key_inner(address: &Address, input_key: &[u8; 32], overflow: bool) -> TreeKey {
     let mut hasher = Sha256::new();
     hasher.update(ZERO_PREFIX);
     hasher.update(address.as_slice());
 
-    // Reverse first 31 bytes (big-endian → little-endian), matching Geth:
-    //   buf[i] = offset[30-i]  for i in 0..31
-    //   buf[31] = 1 if overflow, else 0
     let mut buf = [0u8; 32];
-    buf[..31].copy_from_slice(&input_key[..31]);
-    buf[..31].reverse();
+    buf[1..32].copy_from_slice(&input_key[..31]);
     if overflow {
-        buf[31] = 1;
+        buf[0] = 1;
     }
     hasher.update(buf);
 
@@ -315,28 +311,28 @@ mod tests {
         B256::from_slice(&bytes)
     }
 
-    /// Test key derivation against values computed from Geth's algorithm:
-    /// SHA256(zero[:12] || addr || reversed(key[:31]) || overflow)
+    /// Test key derivation against values computed from geth's V3 algorithm:
+    /// `SHA256(zero[:12] || addr || [overflow, key[0..31]])` (right-shift, no reversal)
     #[test]
     fn test_key_derivation_geth_vectors() {
         let address = Address::repeat_byte(0x42);
 
-        // Basic data key: input_key = all zeros, reversed = all zeros, buf = [0;32]
+        // Basic data key: input_key = all zeros, buf = [0;32]
         let key = get_basic_data_key(&address);
         let expected =
             hex_to_b256("5851f2118c28d2a77e2535442cd4bcf21c7ad2de368b7d0609833d9d2eea1500");
-        assert_eq!(key.to_bytes(), expected, "basic_data_key must match Geth");
+        assert_eq!(key.to_bytes(), expected, "basic_data_key must match geth");
 
-        // Main storage slot 100: offset=[1,0,...,0,100], reversed buf=[0,...,0,1,0]
+        // Main storage slot 100: k[0]=1, k[31]=100, buf=[0,1,0,...,0]
         let mut slot_bytes = [0u8; 32];
         slot_bytes[31] = 100;
         let key = get_storage_slot_key(&address, &slot_bytes);
         let expected =
-            hex_to_b256("7254eaede3e09db532fff12affd6e83b02354608264472882f9c64e9b18abc64");
+            hex_to_b256("44b7da189e7dc329772dc8dd48713599d87483de3e185cdda08ee984ff232b64");
         assert_eq!(
             key.to_bytes(),
             expected,
-            "storage_slot_key(100) must match Geth"
+            "storage_slot_key(100) must match geth"
         );
 
         // Storage slot with overflow: slot[0]=0xff wraps, overflow flag set
@@ -345,11 +341,11 @@ mod tests {
         slot_bytes[31] = 0x20;
         let key = get_storage_slot_key(&address, &slot_bytes);
         let expected =
-            hex_to_b256("f7dc034274011114ac420c79e0b8450a85750ee9ccd93cff48bbc61323e00220");
+            hex_to_b256("15f75dac4bd2d1021375f704f4af439b53738dffce876b33b3ed0e18773cd220");
         assert_eq!(
             key.to_bytes(),
             expected,
-            "storage_slot_key(0xff..0020) with overflow must match Geth"
+            "storage_slot_key(0xff..0020) with overflow must match geth"
         );
     }
 


### PR DESCRIPTION
## Summary

- Update `get_binary_tree_key_inner` from superseded V2 (LE reversal) to current V3 (right-shift) algorithm, matching geth commit `735bfd12` (Apr 13, 2026)
- Regenerate test vectors for V3

## What changed

**V2 (old, removed):**
```rust
buf[..31].copy_from_slice(&input_key[..31]);
buf[..31].reverse();  // LE reversal
if overflow { buf[31] = 1; }
```

**V3 (new, current geth):**
```rust
buf[1..32].copy_from_slice(&input_key[..31]);  // right-shift by 1
if overflow { buf[0] = 1; }
```

## Impact

| Key type | Affected? | Why |
|----------|-----------|-----|
| Basic data, code hash | No | All-zero input — reversal is no-op |
| Storage slots 0-63 | No | Same reason |
| **Storage slots >= 64** | **Yes** | Non-zero tree index bytes |
| Code chunks 0-127 | No | Stays in account stem subtree |
| **Code chunks >= 128** | **Yes** | Non-zero tree index bytes |

## Test plan

- [x] 93 lib tests pass (including updated geth vectors)
- [x] 57 proptests pass
- [x] 27 simulation tests pass
- [x] 5 doc-tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Key derivation algorithm updated to align with go-ethereum's V3 specification, ensuring compatibility with the latest standard.

* **Tests**
  * Updated test vectors to validate the new key derivation behavior across various input scenarios.

* **Documentation**
  * Added documentation describing V3 key derivation specification changes and implementation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->